### PR TITLE
update default image to use docker hub  rather than baidubce

### DIFF
--- a/mkfile/runner.go
+++ b/mkfile/runner.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultDockerImage = "hub.baidubce.com/xchain/emcc:1.0.0"
+	defaultDockerImage = "xuper/emcc:0.1.0"
 	DefaultXROOT       = "/opt/xchain"
 )
 


### PR DESCRIPTION
## Description
update default image to use docker hub  rather than hub.baidubce.com

## Type of change


- [x] New feature (non-breaking change which adds functionality)
